### PR TITLE
Added cache database and User-Agent HTTP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # 68k-news
 Source for the 68k.news site
+
+---
+
+I added an SQLite3 cache database in which the articles are stored for 24h. After that period they automatically get deleted.
+
+The database can be disabled by changing the `USE_CACHE` define in `article.php`.
+
+If the database file becomes corrupted, the program will try to delete and recreate it. (This can be turned off by setting `RECREATE_ON_FAIL` to `false` in `cache_database.php`).
+
+The default cache freshness lifetime is 24h, however it can be changed using the `MAX_CACHE_TIME` parameter in `cache_database.php` along with the default cache database filename (`cache.db`).
+
+I also had to add a spoofed User-Agent header, because some articles couldn't load without it.

--- a/cache_database.php
+++ b/cache_database.php
@@ -1,0 +1,62 @@
+<?php
+define('MAX_CACHE_TIME', 86400); //24 hours in seconds
+define('RECREATE_ON_FAIL', true);
+define('CACHE_DATABASE', "cache.db");
+
+class CacheDatabase extends SQLite3{
+    private static $instance = null;
+
+    private function __construct($path){
+        try{
+            parent::__construct($path);
+            $this->exec("CREATE TABLE IF NOT EXISTS cache(id INTEGER PRIMARY KEY AUTOINCREMENT, url TEXT UNIQUE, epoch INTEGER, title TEXT, content BLOB, images TEXT)");
+        }catch(Exception $ex){
+            trigger_error("Error opening database: " . $ex->getMessage());
+        }
+    }
+
+    public function getFromCache($url){
+        if(!$statement = $this->prepare("SELECT content, title, images FROM cache WHERE url = ?")){
+            return null;
+        }
+        $statement->bindParam(1, $url);
+        if(!$result = $statement->execute()) return null;
+        if(!$row = $result->fetchArray(SQLITE3_ASSOC)) return null;
+        return array(
+            0 => $row['title'],
+            1 => $row['content'],
+            2 => unserialize($row['images'])
+        );
+    }
+
+    public function writeToCache($url, $title, $content, $images){
+        if($cleanStatement = $this->prepare("DELETE FROM cache WHERE epoch < ?")){
+            $cleanStatement->bindValue(1, time() - MAX_CACHE_TIME);
+            $cleanStatement->execute();
+        }
+        if($statement = $this->prepare("INSERT INTO cache (url, epoch, title, content, images) VALUES (?, ?, ?, ?, ?)")){
+            $statement->bindValue(1, $url);
+            $statement->bindValue(2, time());
+            $statement->bindValue(3, $title);
+            $statement->bindValue(4, $content);
+            $statement->bindValue(5, serialize($images));
+            $statement->execute();
+        }else{
+            trigger_error("Cache database writing error");
+            if(RECREATE_ON_FAIL){
+                trigger_error("Deleting database");
+                $this->close();
+                unlink(CACHE_DATABASE);
+                self::$instance = new CacheDatabase(CACHE_DATABASE);
+            }
+        }
+    }
+
+    public static function getInstance(){
+        if(is_null(self::$instance)){
+            self::$instance = new CacheDatabase(CACHE_DATABASE);
+        }
+        return self::$instance;
+    }
+}
+?>


### PR DESCRIPTION
This should improve the page loading speed and prevent rate limiting on the news servers. I also encountered `403 Forbidden` errors caused by the missing User-Agent HTTP header - this should fix them. The database functionality can be turned off using the `USE_CACHE` define in `article.php`. If the database ever becomes corrupted, it will be deleted and recreated. If that fails, the script will just ignore it and load the page without caching it. The cached articles will automatically get deleted after a period of 24 hours.