### PR TITLE
URL-encode links for Mosaic compatibility

### DIFF
--- a/article.php
+++ b/article.php
@@ -11,7 +11,7 @@ if( isset( $_GET['loc'] ) ) {
 }
 
 if( isset( $_GET['a'] ) ) {
-    $article_url = $_GET["a"];
+    $article_url = urldecode($_GET["a"]);
 } else {
     echo "What do you think you're doing... >:(";
     exit();
@@ -76,7 +76,7 @@ function clean_str($str) {
             //we can only do png and jpg
             if (strpos($image_url, ".jpg") || strpos($image_url, ".jpeg") || strpos($image_url, ".png") === true) {
                 $img_num++;
-                $imgline_html .= " <a href='image.php?loc=" . $loc . "&i=" . $image_url . "'>[$img_num]</a> ";
+                $imgline_html .= " <a href='image.php?loc=" . $loc . "&i=" . urlencode($image_url) . "'>[$img_num]</a> ";
             }
         endforeach;
         if($img_num>0) {

--- a/image.php
+++ b/image.php
@@ -9,7 +9,7 @@
     
     //get the image url
     if (isset( $_GET['i'] ) ) {
-        $url = $_GET[ 'i' ];
+        $url = urldecode($_GET[ 'i' ]);
     } else {
         exit();
     }

--- a/index.php
+++ b/index.php
@@ -79,12 +79,15 @@ function clean_str($str) {
 	foreach ($feed->get_items() as $item):
 	?>
  
-			<h3><font size="5"><a href="<?php echo 'article.php?loc=' . $loc . '&a=' . $item->get_permalink(); ?>"><?php echo clean_str($item->get_title()); ?></a></font></h3>
+			<h3><font size="5"><a href="<?php echo 'article.php?loc=' . $loc . '&a=' . urlencode($item->get_permalink()); ?>"><?php echo clean_str($item->get_title()); ?></a></font></h3>
 			<p><font size="4"><?php 
             $subheadlines = clean_str($item->get_description());
             $remove_google_link = explode("<li><strong>", $subheadlines);
             $no_blank = str_replace('target="_blank"', "", $remove_google_link[0]) . "</li></ol></font></p>"; 
-            $cleaned_links = str_replace('<a href="', '<a href="article.php?loc=' . $loc . '&a=', $no_blank);
+            $url_encoded_links = preg_replace_callback('/href="(.+?)"/',
+                    function($m) { return 'href="' . urlencode($m[1]) . '"'; },
+                    $no_blank); 
+            $cleaned_links = str_replace('<a href="', '<a href="article.php?loc=' . $loc . '&a=', $url_encoded_links);
 			$cleaned_links = strip_tags($cleaned_links, '<a><ol><ul><li><br><p><small><font><b><strong><i><em><blockquote><h1><h2><h3><h4><h5><h6>');
     		$cleaned_links = str_replace( 'strong>', 'b>', $cleaned_links); //change <strong> to <b>
     		$cleaned_links = str_replace( 'em>', 'i>', $cleaned_links); //change <em> to <i>


### PR DESCRIPTION
Article and image links contained non-URL characters in the query string, which caused "error -10" in NCSA Mosaic 1.0 on Windows 3.1. Apparently Mosaic was stricter about URL encoding than later browsers. Added URL encoding and corresponding decoding for article and image links. Now I can read the news on my 386!
![IMG_8797](https://user-images.githubusercontent.com/16436731/178079011-f7f35512-94ca-4d85-80bf-2ad809616bce.jpg)
