### PR TITLE
Add a basic dockerfile for container deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:8.2-fpm
+
+RUN apt update && apt -y install libzip-dev unzip git
+
+RUN pecl install zip
+
+COPY . /68k-news
+
+WORKDIR /68k-news
+
+RUN mkdir -pv cache
+
+RUN chmod +x composer.phar
+RUN ./composer.phar i
+
+RUN curl -LO https://github.com/simplepie/simplepie/releases/download/1.8.0/SimplePie.compiled.php && mv SimplePie.compiled.php vendor
+
+EXPOSE 8080
+
+CMD [ "php", "-S", "0.0.0.0:8080", "-t", "./" ]


### PR DESCRIPTION
This Dockerfile performs what seems to be the required setup actions for the 68k-news site and builds them into a Docker container image. By default it runs the simple PHP development server which should be enough for most self-hosters out there.

This can be built on a system running Docker with: 

`docker build -t 68k-news`

And run with:

`docker run -p 8080:8080 --name 68k-news 68k-news`

If you need a Docker solution to test this with, I recommend the excellent OrbStack - https://orbstack.dev

Sorry if the edits are spamming you, I keep having new thoughts. Feel free to reach out for any needed info!
